### PR TITLE
feat(ts-config): Add default `file` patterns for all TypeScript configs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,15 +104,7 @@ objects into your own configuration array:
     const EslintConfig = [
         CommonConfig,
     
-        ...TsConfigArray.map(
-            (config) => ({
-                files: [
-                    "**/*.ts",
-                    "**/*.tsx",
-                ],
-                ...config,
-            })
-        ),
+        ...TsConfigArray,
 
         // NOTE: `StylisticConfigArray` must be placed after `TsConfigArray` to override stylistic
         // rules within `TsConfigArray` (we can't remove the stylistic rules from `TsConfigArray`
@@ -145,15 +137,8 @@ objects into your own configuration array:
            ],
        },
        CommonConfig,
-       ...TsConfigArray.map(
-           (config) => ({
-               files: [
-                   "**/*.ts",
-                   "**/*.tsx",
-               ],
-               ...config,
-           })
-       ),
+   
+       ...TsConfigArray,
        createTsConfigOverride(
            [
                "src/**/*.ts",
@@ -165,6 +150,7 @@ objects into your own configuration array:
            ["vite.config.ts"],
            "tsconfig.node.json"
        ),
+   
        ...StylisticConfigArray,
        ...ReactConfigArray,
    ];

--- a/TsConfigArray.mjs
+++ b/TsConfigArray.mjs
@@ -66,7 +66,15 @@ const TsConfigArray = [
             },
         },
     },
-];
+].map(
+    (config) => ({
+        files: [
+            "**/*.ts",
+            "**/*.tsx",
+        ],
+        ...config,
+    })
+);
 
 export {createTsConfigOverride};
 export default TsConfigArray;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
  - Enhanced TypeScript configuration to explicitly include `.ts` and `.tsx` files
  - Refined configuration array processing to improve file selection mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->