### PR TITLE
feat(common-config): Add autofix for `sort-keys` (resolves #17).

### DIFF
--- a/CommonConfig.mjs
+++ b/CommonConfig.mjs
@@ -358,11 +358,7 @@ const CommonConfig = {
             },
         ],
         "sort-imports": ["off"],
-        "sort-keys": [
-            "warn",
-            "asc",
-            {allowLineSeparatedGroups: true, caseSensitive: true, minKeys: 5, natural: true},
-        ],
+        "sort-keys": ["off"],
         "sort-keys-plus/sort-keys": [
             "warn",
             "asc",

--- a/CommonConfig.mjs
+++ b/CommonConfig.mjs
@@ -5,6 +5,7 @@ import ImportNewlinesPlugin from "eslint-plugin-import-newlines";
 import JsdocPlugin from "eslint-plugin-jsdoc";
 import NoAutofixPlugin from "eslint-plugin-no-autofix";
 import SimpleImportSortPlugin from "eslint-plugin-simple-import-sort";
+import SortKeysPlusPlugin from "eslint-plugin-sort-keys-plus";
 
 
 const CommonConfig = {
@@ -18,6 +19,7 @@ const CommonConfig = {
         "jsdoc": JsdocPlugin,
         "no-autofix": NoAutofixPlugin,
         "simple-import-sort": SimpleImportSortPlugin,
+        "sort-keys-plus": SortKeysPlusPlugin,
     },
     rules: {
         "accessor-pairs": ["error"],
@@ -357,6 +359,11 @@ const CommonConfig = {
         ],
         "sort-imports": ["off"],
         "sort-keys": [
+            "warn",
+            "asc",
+            {allowLineSeparatedGroups: true, caseSensitive: true, minKeys: 5, natural: true},
+        ],
+        "sort-keys-plus/sort-keys": [
             "warn",
             "asc",
             {allowLineSeparatedGroups: true, caseSensitive: true, minKeys: 5, natural: true},

--- a/StylisticConfigArray.mjs
+++ b/StylisticConfigArray.mjs
@@ -96,7 +96,7 @@ const StylisticConfigArray = [
             ],
             "@stylistic/lines-around-comment": [
                 "error",
-                /* eslint-disable sort-keys */
+                /* eslint-disable sort-keys-plus/sort-keys */
                 {
                     ignorePattern: "c8|Enum",
                     beforeBlockComment: true,
@@ -123,7 +123,7 @@ const StylisticConfigArray = [
                     allowTypeStart: true,
                     allowTypeEnd: true,
                 },
-                /* eslint-enable sort-keys */
+                /* eslint-enable sort-keys-plus/sort-keys */
             ],
             "@stylistic/lines-between-class-members": ["error"],
             "@stylistic/max-len": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
+        "eslint-plugin-sort-keys-plus": "^1.4.0",
         "globals": "^15.14.0",
         "typescript-eslint": "8.19.0"
       }
@@ -2042,6 +2043,20 @@
       "peer": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sort-keys-plus": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-keys-plus/-/eslint-plugin-sort-keys-plus-1.4.0.tgz",
+      "integrity": "sha512-4MsaETpu8+Atfhp3kyz+vu5ATHfst/vkAhVFUkzEDDgq39jpecGAbSVNGKd0OfDK7TDLGoeNzxnCLrMM06zvNg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/eslint-rule-composer": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-react": "^7.37.3",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-sort-keys-plus": "^1.4.0",
     "globals": "^15.14.0",
     "typescript-eslint": "8.19.0"
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR is to add support for autofix of `sort-keys`. (#17 )

It seems "sort-keys-fix" only accept `caseSentive` and `natural` values, there is no `allowLineSeparatedGroups` and `minKeys`, and this project seems not actively maintained. I found this fork: https://www.npmjs.com/package/eslint-plugin-sort-keys-plus which supports the `allowLineSeparatedGroups` and `minKeys`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Run `eslint .` at the root directory of this project, and found 13 warnings (before use `eslint-plugin-sort-keys-plus` there were much more warnings because it didn't allow line separated groups and minimum keys) and 1 error, and all warnings were related to sort issues:
```
  102:21  warning  Expected object keys to be in natural ascending order. 'beforeBlockComment' should be before 'ignorePattern'       sort-keys-plus/sort-keys
  103:21  warning  Expected object keys to be in natural ascending order. 'afterBlockComment' should be before 'beforeBlockComment'   sort-keys-plus/sort-keys
  105:21  warning  Expected object keys to be in natural ascending order. 'afterLineComment' should be before 'beforeLineComment'     sort-keys-plus/sort-keys
  106:21  warning  Expected object keys to be in natural ascending order. 'afterHashbangComment' should be before 'afterLineComment'  sort-keys-plus/sort-keys
  108:21  warning  Expected object keys to be in natural ascending order. 'allowBlockEnd' should be before 'allowBlockStart'          sort-keys-plus/sort-keys
  110:21  warning  Expected object keys to be in natural ascending order. 'allowClassEnd' should be before 'allowClassStart'          sort-keys-plus/sort-keys
  112:21  warning  Expected object keys to be in natural ascending order. 'allowObjectEnd' should be before 'allowObjectStart'        sort-keys-plus/sort-keys
  113:21  warning  Expected object keys to be in natural ascending order. 'allowArrayStart' should be before 'allowObjectEnd'         sort-keys-plus/sort-keys
  114:21  warning  Expected object keys to be in natural ascending order. 'allowArrayEnd' should be before 'allowArrayStart'          sort-keys-plus/sort-keys
  118:21  warning  Expected object keys to be in natural ascending order. 'allowEnumEnd' should be before 'allowEnumStart'            sort-keys-plus/sort-keys
  120:21  warning  Expected object keys to be in natural ascending order. 'allowInterfaceEnd' should be before 'allowInterfaceStart'  sort-keys-plus/sort-keys
  122:21  warning  Expected object keys to be in natural ascending order. 'allowModuleEnd' should be before 'allowModuleStart'        sort-keys-plus/sort-keys
  124:21  warning  Expected object keys to be in natural ascending order. 'allowTypeEnd' should be before 'allowTypeStart'            sort-keys-plus/sort-keys
```

It is surprising that the lint project itself is not well linted -_-||

And then I use WebStorm to check these warnings, it can show the fix option with yellow warning like:
<img width="819" alt="image" src="https://github.com/user-attachments/assets/de477b51-da65-4ad1-9e0c-127153c7e0ab" />

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated ESLint configuration to include the sort-keys-plus plugin for improved key sorting enforcement.
  - Added eslint-plugin-sort-keys-plus as a peer dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->