### PR TITLE
fix: Modify import for `eslint-plugin-import` plugin to prevent redefinition error when using workspaces.

### DIFF
--- a/CommonConfig.mjs
+++ b/CommonConfig.mjs
@@ -13,7 +13,7 @@ const CommonConfig = {
         sourceType: "module",
     },
     plugins: {
-        "import": ImportPlugin,
+        "import": ImportPlugin.flatConfigs.recommended.plugins.import,
         "import-newlines": ImportNewlinesPlugin,
         "jsdoc": JsdocPlugin,
         "no-autofix": NoAutofixPlugin,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

PR makes a minor change to how `eslint-plugin-import` is imported in the common config. 
See issue #21 for more details.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested with workspace PR, and linter error is gone



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
